### PR TITLE
Product's base price is shown in discounts table instead of discounted value

### DIFF
--- a/product.tpl
+++ b/product.tpl
@@ -519,11 +519,7 @@
                       {/if}
                     {else}
                       {if $display_discount_price}
-                        {if $quantity_discount.reduction_tax == 0}
-                          {convertPrice price = $productPriceWithoutReduction|floatval-($productPriceWithoutReduction*$quantity_discount.reduction_with_tax)|floatval}
-                        {else}
-                          {convertPrice price = $productPriceWithoutReduction|floatval-($productPriceWithoutReduction*$quantity_discount.reduction)|floatval}
-                        {/if}
+                        {convertPrice price = $productPriceWithoutReduction|floatval-($productPriceWithoutReduction*$quantity_discount.reduction)|floatval}                        
                       {else}
                         {$quantity_discount.real_value|floatval}%
                       {/if}


### PR DESCRIPTION
Product's base price is shown in the discounts table instead of discounted values, when the catalog price rule is percentage and has "Tax Excluded" option selected.
When discount type is percentage it shouldn't matter if tax is included or excluded.
More info: https://forum.thirtybees.com/topic/3658-niara-theme-wrong-calculation-of-volume-discounts-problems-and-solutions/ - Case 3