### PR TITLE
Removed the compass npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "scan-translations": "./node_modules/.bin/gulp scan-translations"
   },
   "dependencies": {
-    "compass": "^0.1.1",
     "node-bourbon": "^4.2.8"
   }
 }

--- a/sass/autoload/compatibility/_type.scss
+++ b/sass/autoload/compatibility/_type.scss
@@ -1,4 +1,3 @@
-// From @import 'compass/reset'
 // @TODO Disable this during development, reset styles for lists separately
 ul {
   list-style: none;


### PR DESCRIPTION
I removed the compass npm package, as it was only reference once - in a comment. Both comment and npm package removed for simplifying dependencies.