### PR TITLE
Renamed format-js to lint-js. Do not output files to JS-folder.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,5 +53,5 @@ jspm_packages
 yarn.lock
 .idea/
 
-#bug fix for jscsrc
-js/gulpfile.js
+# NPM lock file
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ npm install
 ```
 npm run compile-css
 ```
-### Building JavaScript
+### Linting JavaScript
 ```
-npm run format-js
+npm run lint-js
 ```
 
 ## Contributing

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -107,7 +107,7 @@ gulp.task('copy-index', function(callback) {
 	});
 });
 
-gulp.task('format-js', function() {
+gulp.task('lint-js', function() {
 
 	return gulp.src([
 		'./gulpfile.js',
@@ -117,8 +117,7 @@ gulp.task('format-js', function() {
 		'!./js/debug/**/*.js'
 	])
 		.pipe(eslint())
-		.pipe(eslint.format())
-		.pipe(gulp.dest('./js/'));
+		.pipe(eslint.format());
 });
 
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "watch-sass": "./node_modules/.bin/gulp watch-sass",
     "clean-up": "./node_modules/.bin/gulp clean-up",
     "copy-index": "./node_modules/.bin/gulp copy-index",
-    "format-js": "./node_modules/.bin/gulp format-js",
+    "lint-js": "./node_modules/.bin/gulp lint-js",
     "scan-translations": "./node_modules/.bin/gulp scan-translations"
   },
   "dependencies": {}


### PR DESCRIPTION
This fixes #29 .

I think "format-js" tells me that it modifies the the JS-files - but it does not. It only lints the files.
I have also changed the documentation, to precise that JS-files are not builded, but only linted.

As a sidestep I have added package-lock.json generated by "npm install" to .gitignore