### PR TITLE
fixes #43 comment review rating not registering

### DIFF
--- a/modules/productcomments/productcomments.tpl
+++ b/modules/productcomments/productcomments.tpl
@@ -14,6 +14,7 @@
             <div class="form-group">
               <div><b>{l s='Grade' mod='productcomments'}</b></div>
               <div class="star_content clearfix"  itemprop="reviewRating" itemscope itemtype="https://schema.org/Rating">
+				<meta itemprop="ratingValue" content="{$comment.grade|escape:'html':'UTF-8'}">
                 {section name="i" start=0 loop=5 step=1}
                   {if $comment.grade <= $smarty.section.i.index}
                     <div class="star"></div>


### PR DESCRIPTION

Fixes #43 
- found that according to spec, review rating  value needs to be inside the reviewRating block.
- I have left the original one outside the block, in case other platforms use it in this format.