### PR TITLE
Make blocklayered collapsible on mobile

### DIFF
--- a/css/modules/blocklayered/blocklayered.css
+++ b/css/modules/blocklayered/blocklayered.css
@@ -1,3 +1,18 @@
+#layered_title {
+  padding-top: 10px;
+}
+
+#layered_title .title_block {
+  padding-top: 0;
+  margin-bottom: 0;
+}
+
+#layered_toggle {
+  float: right;
+  font-size: 16px;
+  line-height: 1.42857143;
+}
+
 #enabled_filters {
   margin: 0 0 10px 0;
   background: #eee;

--- a/js/modules/blocklayered/blocklayered.js
+++ b/js/modules/blocklayered/blocklayered.js
@@ -627,6 +627,13 @@ function initLayered() {
         }
       });
 
+      $(document).on('click', '#layered_toggle', function (e) {
+        e.preventDefault();
+        $('#layered_block_left .block_content').toggleClass('hidden-xs');
+        $(this).find('.icon').toggleClass('icon-plus');
+        $(this).find('.icon').toggleClass('icon-minus');
+      });
+
       // Global var
       window.layered_hidden_list = {};
 

--- a/modules/blocklayered/blocklayered.tpl
+++ b/modules/blocklayered/blocklayered.tpl
@@ -2,8 +2,11 @@
     <section>
         <nav>
             <div id="layered_block_left" class="block">
-                <h2 class="title_block section-title-column">{l s='Catalog' mod='blocklayered'}</h2>
-                <div class="block_content">
+                <div id="layered_title">
+                    <a id="layered_toggle" class="visible-xs-block" href="#"><i class="icon icon-fw icon-plus"></i></a>
+                    <h2 class="title_block section-title-column">{l s='Catalog' mod='blocklayered'}</h2>
+                </div>
+                <div class="block_content hidden-xs">
                     <form action="#" id="layered_form">
                         <div>
                             {if isset($selected_filters) && $n_filters > 0}

--- a/sass/modules/blocklayered/blocklayered.scss
+++ b/sass/modules/blocklayered/blocklayered.scss
@@ -1,6 +1,20 @@
-
 @import "./../../theme_variables";
 @import "./../../vendor_variables";
+
+#layered_title {
+  padding-top: 10px;
+
+  .title_block {
+    padding-top: 0;
+    margin-bottom: 0;
+  }
+}
+
+#layered_toggle {
+  float: right;
+  font-size: $font-size-h4;
+  line-height: $line-height-base;
+}
 
 #enabled_filters {
   margin: 0 0 10px 0;
@@ -21,7 +35,6 @@
 }
 
 #layered_form {
-
   ul {
     padding: 0;
     margin: 0 0 10px;


### PR DESCRIPTION
This will make blocklayered collapsed by default on mobile like this: | When pressing the plus button, it will look like this:
-- | --
![Screen Shot 2022-07-24 at 21 46 03](https://user-images.githubusercontent.com/87533231/180663365-8c32f261-ce93-47fb-8dab-7664708981ee.png) | ![Screen Shot 2022-07-24 at 21 46 08](https://user-images.githubusercontent.com/87533231/180663366-b63c0b08-4f53-436c-95e9-112fbf87dbe4.png)

This way, customers won't have to scroll past the large filter menu on mobile, but could immediately see the products. This is especially useful when you have a lot of filters with a lot of options.

## To do

- [ ] Make the whole line clickable instead of only the plus button like with the other menus
- [ ] Make the filters not disappear after selecting something so the customer will not have to open it again