### PR TITLE
Dropdown Cart on mobile fix

### DIFF
--- a/js/modules/blockcart/ajax-cart.js
+++ b/js/modules/blockcart/ajax-cart.js
@@ -18,42 +18,51 @@ $(function() {
 
   var hoverCollapseTimeout = 200;
 
-  $cartHeader.on({
-    mouseenter: function() {
-      if (ajaxCart.nb_total_products > 0 || parseInt($('.ajax_cart_quantity').html()) > 0)
-        $cartDropDown.stop(true, true).slideDown();
-    },
-    mouseleave: function() {
-      setTimeout(function() {
-        if (!oBlockcart.isHoveringOver() && !oBlockcartDropDown.isHoveringOver())
-          $cartDropDown.stop(true, true).slideUp();
-      }, hoverCollapseTimeout);
-    },
-    click: function(e) {
-      e.preventDefault();
-      e.stopPropagation();
-
-      // Simulate hover when browser says device is touch based
-      if (is_touch_enabled) {
-        if ($(this).next('.cart_block:visible').length && !oBlockcartDropDown.isHoveringOver()) {
-          $cartDropDown.stop(true, true).slideUp();
-        } else if (ajaxCart.nb_total_products > 0 || parseInt($('.ajax_cart_quantity').html()) > 0) {
-          $cartDropDown.stop(true, true).slideDown();
-        }
-        return false;
-      } else {
-        window.location.href = $(this).attr('href');
-      }
-    }
-  });
-
-  $cartDropDown.on('mouseleave', function() {
-    setTimeout(function() {
-      if (!oBlockcart.isHoveringOver()) {
-        $cartDropDown.stop(true, true).slideUp();
-      }
-    }, hoverCollapseTimeout);
-  });
+	if (!is_touch_enabled) {
+		$cartHeader.on({
+		 mouseenter: function() {
+			if (ajaxCart.nb_total_products > 0 || parseInt($('.ajax_cart_quantity').html()) > 0)
+			  $cartDropDown.stop(true, true).slideDown();
+		 },
+		 mouseleave: function() {
+			setTimeout(function() {
+			  if (!oBlockcart.isHoveringOver() && !oBlockcartDropDown.isHoveringOver())
+				 $cartDropDown.stop(true, true).slideUp();
+			}, hoverCollapseTimeout);
+		 },
+		 click: function(e) {
+			e.preventDefault();
+			e.stopPropagation();
+		 }
+		});
+		$cartDropDown.on('mouseleave', function() {
+		 setTimeout(function() {
+			if (!oBlockcart.isHoveringOver()) {
+			  $cartDropDown.stop(true, true).slideUp();
+			}
+		 }, hoverCollapseTimeout);
+		});
+	} else {
+		$cartHeader.on({
+			click: function(e) {
+				e.preventDefault();
+				e.stopPropagation();
+				if ($(this).next('.cart_block:visible').length && !oBlockcartDropDown.isHoveringOver()) {
+					$cartDropDown.stop(true, true).slideUp();
+				} else if (ajaxCart.nb_total_products > 0 || parseInt($('.ajax_cart_quantity').html()) > 0) {
+					$cartDropDown.stop(true, true).slideDown();
+				}
+				return false;
+			}
+		});
+		// close $cartDropDown even with tap out anywhere
+		$(document).click(function (e) {
+			e.stopPropagation();
+			if ( $cartDropDown.has(e.target).length === 0) {
+				$cartDropDown.stop(true, true).slideUp();
+			}
+		});
+	}
 
   $(document).on('click', '.delete_voucher', function(e) {
     e.preventDefault();


### PR DESCRIPTION
On Chrome, when some product is added to cart, in both Thirtybees themes - "Niara" and "Comunity Theme Default", dropdown cart make on first tap strange move of sliding up instead of sliding down, on mobile Chrome or browser Chrome in DevTools mobile mode with touch enabled.
It happens just on very first tap on cart icon placed right top in header on each of eshop pages. Then it works correctly until page reload.
After reload again, first tap on cart icon and dropdown cart hidden trigger not dropdown slide-down but slide-up, then again OK.
On Firefox and Safari this anomaly was not present, just Chrome (mobile).

Notice: this is very old behavior, it happens on Prestshops 1.6.x original theme too, and it was brought to Thirtybees then.