### PR TITLE
Fix Customer Order History scroll to detail on Chrome

### DIFF
--- a/js/history.js
+++ b/js/history.js
@@ -20,7 +20,9 @@ function showOrder(mode, var_content, file) {
         bindOrderDetailForm();
 
         $blockOrderDetail.fadeIn(function() {
-          $.scrollTo($blockOrderDetail, 1000, {offset: -(50 + 10)});
+          $('html, body').animate({
+            scrollTop: $blockOrderDetail.offset().top
+          }, 1000);
         });
       });
     }


### PR DESCRIPTION
As customer click or tap (on mobile) on is account History Order page to any row in table list of his orders, to view detail of certain order,
page should load with ajax order detail with ajax under table with list of orders and automatically scroll into position of order detail. It work correctly on Firefox, Safari.. but Chrome browsers are not scrolling down and customer can´t notice that order content is already loaded under table.
This fix is crossbrowser compatible.