### PR TITLE
Fix icon alignment

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -6444,7 +6444,7 @@ button.close {
 
 .icon-fw {
   width: 1.28571429em;
-  text-align: center;
+  text-align: left;
 }
 
 .icon-ul {


### PR DESCRIPTION
Fixes the icon alignment (position), to be on the left, so it matches with the other icons of the options from User Zone.