### PR TITLE
Fixed EOL handling by Sass

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,6 +10,7 @@ var sourcemaps = require('gulp-sourcemaps');
 var notify = require('gulp-notify');
 var gulpif = require('gulp-if');
 var options = require('./package.json').options;
+var eol = require('gulp-eol');
 
 var createFolders = [
 	'./cache/',
@@ -63,6 +64,7 @@ gulp.task('compile-css', function() {
 			}).on('error', sass.logError)
 		)
 		.pipe(autoprefixer())
+		.pipe(eol())
 		.pipe(gulpif(options.sourcemaps, sourcemaps.write('./')))
 		.pipe(gulp.dest('./css/'))
 		.pipe(displayNotification({

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "glob-all": "^3.1.0",
     "gulp": "^4.0.1",
     "gulp-autoprefixer": "^7.0.1",
+    "gulp-eol": "^0.2.0",
     "gulp-eslint": "^6.0.0",
     "gulp-if": "^3.0.0",
     "gulp-notify": "^3.2.0",


### PR DESCRIPTION
By default Sass generates target files with Unix EOL on all systems. To fix that I've added gulp-eol step, which changes EOL according to OS.

Please follow [https://docs.github.com/en/get-started/git-basics/configuring-git-to-handle-line-endings](https://docs.github.com/en/get-started/git-basics/configuring-git-to-handle-line-endings) to configure automatic EOL handling by GIT.