### PR TITLE
Hide language selector when there is only 1 language

### DIFF
--- a/modules/blocklanguages/blocklanguages.tpl
+++ b/modules/blocklanguages/blocklanguages.tpl
@@ -1,4 +1,4 @@
-{if !empty($languages)}
+{if !empty($languages) and count($languages) > 1}
 
   {foreach from=$languages key=k item=language name="languages"}
     {if $language.iso_code == $lang_iso}


### PR DESCRIPTION
Don't display language selector when website uses only one language. Reduces clutter in header navbar in most shops.