### PR TITLE
If product is globally unavailable, then display that product is out …

### DIFF
--- a/js/product.js
+++ b/js/product.js
@@ -510,7 +510,8 @@ function addCombination(
   combination_specific_price
 ) {
 
-  globalQuantity += quantity;
+  if(quantity > 0)
+    globalQuantity += quantity;
 
   var combination = [];
   combination['idCombination'] = idCombination;
@@ -673,7 +674,12 @@ function updateDisplay() {
       $('#quantity_wanted_p:visible').hide();
 
     // display that the product is unavailable with theses attributes
-    if (!selectedCombination['unavailable']) {
+    if(globalQuantity <= 0 && !allowBuyWhenOutOfStock){
+        $availabilityValue
+            .text(doesntExistNoMore)
+            .removeClass('label-success label-warning')
+            .addClass('label-danger');
+    } else if (!selectedCombination['unavailable']) {
       $availabilityValue.text(doesntExistNoMore + (globalQuantity > 0 ? ' ' + doesntExistNoMoreBut : ''));
       if (!allowBuyWhenOutOfStock) {
         $availabilityValue


### PR DESCRIPTION
If product is globally unavailable, then display that product is out of stock, instead of informing client it's available with other options.

This happens if option to hide unavailable products was enabled