### PR TITLE
Proper href escape

### DIFF
--- a/modules/blockcontact/blockcontact.tpl
+++ b/modules/blockcontact/blockcontact.tpl
@@ -10,12 +10,12 @@
             {if $telnumber != ''}
                 <p class="tel">
                     <span class="label">{l s='Phone:' mod='blockcontact'}</span>
-                    <a href="tel:{$telnumber|escape:'html':'UTF-8'}" title="{$telnumber|escape:'html':'UTF-8'}">{$telnumber|escape:'html':'UTF-8'}</a>
+                    <a href="tel:{$telnumber|escape:'url':'UTF-8'}" title="{$telnumber|escape:'html':'UTF-8'}">{$telnumber|escape:'html':'UTF-8'}</a>
                 </p>
             {/if}
             {if $email != ''}
                 <address>
-                    <a href="mailto:{$email|escape:'html':'UTF-8'}"
+                    <a href="mailto:{$email|escape:'url':'UTF-8'}"
                        title="{l s='Contact our expert support team!' mod='blockcontact'}">
                         {l s='Contact our expert support team!' mod='blockcontact'}
                     </a>

--- a/modules/blockcontact/nav.tpl
+++ b/modules/blockcontact/nav.tpl
@@ -10,7 +10,7 @@
         <p class="navbar-text">
             <i class="icon icon-phone"></i>
             {l s='Call us now:' mod='blockcontact'}
-            <a class="phone-link" href="tel:{$telnumber|escape:'html':'UTF-8'}"
+            <a class="phone-link" href="tel:{$telnumber|escape:'url':'UTF-8'}"
                title="{$telnumber|escape:'html':'UTF-8'}">{$telnumber|escape:'html':'UTF-8'}</a>
         </p>
     </li>


### PR DESCRIPTION
Href is url so it should be escaped as url not html. This makes sure that space and any other chars are properly escaped.