### PR TITLE
Change IMG paths to absolute

### DIFF
--- a/modules/beesblog/views/templates/front/category.tpl
+++ b/modules/beesblog/views/templates/front/category.tpl
@@ -30,7 +30,7 @@
 {else}
 	{if isset($showCategoryImage) && $showCategoryImage && isset($categoryImageUrl) && $categoryImageUrl}
 		<div>
-			<img class="img-responsive" alt="{$category->title|escape:'htmlall':'UTF-8'}" src="{$categoryImageUrl|escape:'htmlall':'UTF-8'}">
+			<img class="img-responsive" alt="{$category->title|escape:'htmlall':'UTF-8'}" src="{$link->getMediaLink($categoryImageUrl)|escape:'htmlall':'UTF-8'}">
 			<em>{$category->description}</em>
 			<br />
 			<br />

--- a/modules/beesblog/views/templates/front/post.tpl
+++ b/modules/beesblog/views/templates/front/post.tpl
@@ -27,7 +27,7 @@
         </div>
         {assign var=imagePath value=Media::getMediaPath(BeesBlog::getPostImagePath($post->id))}
         {if ($imagePath)}
-            <img class="img-responsive" alt="{$post->title|escape:'htmlall':'UTF-8'}" src="{$imagePath|escape:'htmlall':'UTF-8'}">
+            <img class="img-responsive" alt="{$post->title|escape:'htmlall':'UTF-8'}" src="{$link->getMediaLink($imagePath)|escape:'htmlall':'UTF-8'}">
         {/if}
         <h4 class="title_block">{$post->title|escape:'htmlall':'UTF-8'}</h4>
         {include file="./post_info.tpl"}

--- a/modules/beesblog/views/templates/front/post_list_item.tpl
+++ b/modules/beesblog/views/templates/front/post_list_item.tpl
@@ -21,7 +21,7 @@
     <div id="beesblog-post-{$post->id|intval}">
        {if ($imagePath)}
                 <a title="{$post->title|escape:'htmlall':'UTF-8'}" href="{$postPath|escape:'htmlall':'UTF-8'}">
-                    <img class="img-responsive" alt="{$post->title|escape:'htmlall':'UTF-8'}" src="{$imagePath|escape:'htmlall':'UTF-8'}">
+                    <img class="img-responsive" alt="{$post->title|escape:'htmlall':'UTF-8'}" src="{$link->getMediaLink($imagePath)|escape:'htmlall':'UTF-8'}">
                 </a>
             {/if}
         <h4 class="title_block">

--- a/modules/beesblogpopularposts/views/templates/hooks/home.tpl
+++ b/modules/beesblogpopularposts/views/templates/hooks/home.tpl
@@ -33,7 +33,7 @@
 								<a href="{$post->link|escape:'htmlall':'UTF-8'}" title="{$post->title|escape:'htmlall':'UTF-8'}">
 									{assign var=imagePath value=Media::getMediaPath(BeesBlog::getPostImagePath($post->id))}
 									{if ($imagePath)}
-										<img class="img-responsive" src="{$imagePath|escape:'htmlall':'UTF-8'}" title="{$post->title|escape:'htmlall':'UTF-8'}" />
+										<img class="img-responsive" src="{$link->getMediaLink($imagePath)|escape:'htmlall':'UTF-8'}" title="{$post->title|escape:'htmlall':'UTF-8'}" />
 									{/if}
 								</a>
 							<h5>

--- a/modules/beesblogpopularposts/views/templates/hooks/product.tpl
+++ b/modules/beesblogpopularposts/views/templates/hooks/product.tpl
@@ -34,7 +34,7 @@
 										<a class="beesblogpopularposts-title" href="{$post->link|escape:'htmlall':'UTF-8'}" title="{$post->title|escape:'htmlall':'UTF-8'}">
 											{assign var=imagePath value=Media::getMediaPath(BeesBlog::getPostImagePath($post->id))}
 											{if ($imagePath)}
-											<img class="img-responsive" src="{$imagePath|escape:'htmlall':'UTF-8'}" title="{$post->title|escape:'htmlall':'UTF-8'}" />
+											<img class="img-responsive" src="{$link->getMediaLink($imagePath)|escape:'htmlall':'UTF-8'}" title="{$post->title|escape:'htmlall':'UTF-8'}" />
 											{/if}
 											{$post->title|escape:'htmlall':'UTF-8'}
 										</a>

--- a/modules/beesblogrecentposts/views/templates/hooks/home.tpl
+++ b/modules/beesblogrecentposts/views/templates/hooks/home.tpl
@@ -34,7 +34,7 @@
 								<a href="{$post->link|escape:'htmlall':'UTF-8'}" title="{$post->title|escape:'htmlall':'UTF-8'}">
 									{assign var=imagePath value=Media::getMediaPath(BeesBlog::getPostImagePath($post->id))}
 									{if ($imagePath)}
-										<img class="img-responsive" src="{$imagePath|escape:'htmlall':'UTF-8'}" title="{$post->title|escape:'htmlall':'UTF-8'}" />
+										<img class="img-responsive" src="{$link->getMediaLink($imagePath)|escape:'htmlall':'UTF-8'}" title="{$post->title|escape:'htmlall':'UTF-8'}" />
 									{/if}
 								</a>
 							<h5>

--- a/modules/beesblogrecentposts/views/templates/hooks/product.tpl
+++ b/modules/beesblogrecentposts/views/templates/hooks/product.tpl
@@ -34,7 +34,7 @@
 										<a class="beesblogrecentposts-title" href="{$post->link|escape:'htmlall':'UTF-8'}" title="{$post->title|escape:'htmlall':'UTF-8'}">
 											{assign var=imagePath value=Media::getMediaPath(BeesBlog::getPostImagePath($post->id))}
 											{if ($imagePath)}
-											<img class="img-responsive" src="{$imagePath|escape:'htmlall':'UTF-8'}" title="{$post->title|escape:'htmlall':'UTF-8'}" />
+											<img class="img-responsive" src="{$link->getMediaLink($imagePath)|escape:'htmlall':'UTF-8'}" title="{$post->title|escape:'htmlall':'UTF-8'}" />
 											{/if}
 											{$post->title|escape:'htmlall':'UTF-8'}
 										</a>

--- a/modules/beesblogrelatedproducts/views/templates/hooks/product.tpl
+++ b/modules/beesblogrelatedproducts/views/templates/hooks/product.tpl
@@ -29,7 +29,7 @@
                             <a class="beesblogrecentposts-title" href="{$post.link|escape:'htmlall':'UTF-8'}" title="{$post.title|escape:'htmlall':'UTF-8'}">
                                 {assign var=imagePath value=Media::getMediaPath(BeesBlog::getPostImagePath($post.id))}
                                 {if ($imagePath)}
-                                    <img class="img-responsive" src="{$imagePath|escape:'htmlall':'UTF-8'}" title="{$post.title|escape:'htmlall':'UTF-8'}" />
+                                    <img class="img-responsive" src="{$link->getMediaLink($imagePath)|escape:'htmlall':'UTF-8'}" title="{$post.title|escape:'htmlall':'UTF-8'}" />
                                 {/if}
                                 {$post.title|escape:'htmlall':'UTF-8'}
                             </a>


### PR DESCRIPTION
Blog module templates use relative paths for images. This means, blog images won't be redirected to CDN media servers when enabled.

This change relative paths to absolute ones with CDN support.